### PR TITLE
Performance fixes in usage of Vulkan Memory Allocator

### DIFF
--- a/framework/core/buffer.cpp
+++ b/framework/core/buffer.cpp
@@ -38,10 +38,12 @@ Buffer::Buffer(Device &device, VkDeviceSize size, VkBufferUsageFlags buffer_usag
 	memory_info.usage = memory_usage;
 	memory_info.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
 
+    VmaAllocationInfo allocInfo{};
 	auto result = vmaCreateBuffer(device.get_memory_allocator(),
 	                              &buffer_info, &memory_info,
 	                              &handle, &memory,
-	                              nullptr);
+	                              &allocInfo);
+    mapped_data = (uint8_t*)allocInfo.pMappedData;
 
 	if (result != VK_SUCCESS)
 	{
@@ -89,27 +91,11 @@ VmaAllocation Buffer::get_memory() const
 
 uint8_t *Buffer::map()
 {
-	if (!mapped_data)
-	{
-		// Map once
-		auto result = vmaMapMemory(device.get_memory_allocator(), memory, reinterpret_cast<void **>(&mapped_data));
-
-		if (result != VK_SUCCESS)
-		{
-			throw VulkanException{result, "Cannot map memory"};
-		}
-	}
-
 	return mapped_data;
 }
 
 void Buffer::unmap()
 {
-	if (mapped_data)
-	{
-		vmaUnmapMemory(device.get_memory_allocator(), memory);
-		mapped_data = nullptr;
-	}
 }
 
 VkDeviceSize Buffer::get_size() const

--- a/framework/core/buffer.cpp
+++ b/framework/core/buffer.cpp
@@ -38,12 +38,12 @@ Buffer::Buffer(Device &device, VkDeviceSize size, VkBufferUsageFlags buffer_usag
 	memory_info.usage = memory_usage;
 	memory_info.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
 
-    VmaAllocationInfo allocInfo{};
+    VmaAllocationInfo alloc_info{};
 	auto result = vmaCreateBuffer(device.get_memory_allocator(),
 	                              &buffer_info, &memory_info,
 	                              &handle, &memory,
-	                              &allocInfo);
-    mapped_data = (uint8_t*)allocInfo.pMappedData;
+	                              &alloc_info);
+    mapped_data = (uint8_t*)alloc_info.pMappedData;
 
 	if (result != VK_SUCCESS)
 	{
@@ -66,8 +66,6 @@ Buffer::Buffer(Buffer &&other) :
 
 Buffer::~Buffer()
 {
-	unmap();
-
 	if (handle != VK_NULL_HANDLE && memory != VK_NULL_HANDLE)
 	{
 		vmaDestroyBuffer(device.get_memory_allocator(), handle, memory);
@@ -89,15 +87,6 @@ VmaAllocation Buffer::get_memory() const
 	return memory;
 }
 
-uint8_t *Buffer::map()
-{
-	return mapped_data;
-}
-
-void Buffer::unmap()
-{
-}
-
 VkDeviceSize Buffer::get_size() const
 {
 	return size;
@@ -105,7 +94,7 @@ VkDeviceSize Buffer::get_size() const
 
 void Buffer::update(const std::vector<uint8_t> &data)
 {
-	std::copy(std::begin(data), std::end(data), map());
+	std::copy(std::begin(data), std::end(data), mapped_data);
 }
 }        // namespace core
 }        // namespace vkb

--- a/framework/core/buffer.h
+++ b/framework/core/buffer.h
@@ -51,13 +51,6 @@ class Buffer : public NonCopyable
 	void update(const std::vector<uint8_t> &data);
 
   private:
-	/// @brief Maps the GPU memory to host memory
-	/// @return A pointer to the memory visible by the host
-	uint8_t *map();
-
-	/// @brief Unmaps memory between GPU and CPU
-	void unmap();
-
 	Device &device;
 
 	VkBuffer handle{VK_NULL_HANDLE};

--- a/framework/core/image.cpp
+++ b/framework/core/image.cpp
@@ -93,7 +93,6 @@ Image::Image(Device &              device,
 
 	VmaAllocationCreateInfo memory_info{};
 	memory_info.usage = memory_usage;
-	memory_info.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
 
 	if (image_usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)
 	{


### PR DESCRIPTION
Hello, I'm the author of Vulkan Memory Allocator. Thank you for using this library :) I have few suggestions related to it:

1. In `Buffer` class, allocations are created as persistently mapped (`VMA_ALLOCATION_CREATE_MAPPED_BIT` flag), so there is no need to map and unmap them. Mapped pointer can just be saved once and returned to the user. Calling `vmaMapMemory`/`vmaUnmapMemory` is correct, but unnecessary. I propose fix for this in the pull request.

2. In `Image` class I suggest not to use `VMA_ALLOCATION_CREATE_MAPPED_BIT` flag. Mapping of images is not used anyway, while passing this flag makes VMA prefer memory types that are `HOST_VISIBLE`, which will outweigh the preference for `LAZILY_ALLOCATED` that you conditionally use. I propose fix for this in the pull request.

3. I can't see any call to Flush or Invalidate. Unlike on desktop PC GPUs, Vulkan implementations on mobile GPUs provide memory types that are `HOST_VISIBLE` but not `HOST_COHERENT`. If such memory type is chosen, Invalidate must be called before CPU code reads mapped memory and Flush must be called after CPU code writes mapped memory.

4. There is a resource leak. For example, when the project is ran with "render_passes" parameter, compiled in Debug configuration, an assert is hit inside VMA indicating that there are some unfreed allocations. These are 2 images with usage `TRANSFER_DST | SAMPLED`.