### PR TITLE
Remove docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,0 @@
-../README.md


### PR DESCRIPTION
We are building github-pages from master rather than master/docs, therefore this symlink is no longer required.