### PR TITLE
Entrypoints Hotfix

### DIFF
--- a/framework/platform/application.cpp
+++ b/framework/platform/application.cpp
@@ -95,7 +95,7 @@ void Application::input_event(const InputEvent &input_event)
 
 void Application::parse_options(const std::vector<std::string> &args)
 {
-	options = std::make_unique<Options>(usage, args);
+	options.parse(usage, args);
 }
 
 void Application::set_usage(const std::string &usage)
@@ -125,7 +125,7 @@ DebugInfo &Application::get_debug_info()
 
 const Options &Application::get_options()
 {
-	return *options;
+	return options;
 }
 
 void Application::set_benchmark_mode(bool benchmark_mode_)

--- a/framework/platform/application.h
+++ b/framework/platform/application.h
@@ -106,7 +106,7 @@ class Application
 
 	static std::string usage;
 
-	std::unique_ptr<Options> options;
+	Options options{};
 
 	static void set_usage(const std::string &usage);
 

--- a/framework/platform/glfw_platform.cpp
+++ b/framework/platform/glfw_platform.cpp
@@ -284,8 +284,18 @@ bool GlfwPlatform::initialize(std::unique_ptr<Application> &&app)
 		glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
 	}
 
-	uint32_t width  = static_cast<uint32_t>(options.get_int("--width"));
-	uint32_t height = static_cast<uint32_t>(options.get_int("--height"));
+	uint32_t width  = 1280;
+	uint32_t height = 720;
+
+	if (options.contains("--width"))
+	{
+		width = static_cast<uint32_t>(options.get_int("--width"));
+	}
+
+	if (options.contains("--height"))
+	{
+		height = static_cast<uint32_t>(options.get_int("--height"));
+	}
 
 	window = glfwCreateWindow(width, height, active_app->get_name().c_str(), NULL, NULL);
 

--- a/framework/platform/options.cpp
+++ b/framework/platform/options.cpp
@@ -24,24 +24,29 @@
 
 namespace vkb
 {
-Options::Options(const std::string &usage, const std::vector<std::string> &args) :
-    usage{usage},
-    parse_result{docopt::docopt(usage, args, false)}
+void Options::parse(const std::string &usage, const std::vector<std::string> &args)
+
 {
+	if (usage.size() != 0)
+	{
+		this->usage        = usage;
+		this->parse_result = docopt::docopt(usage, args, false);
+	}
 }
 
 bool Options::contains(const std::string &argument) const
 {
-	assert(parse_result.count(argument) != 0 && "Argument not specified in usage");
-
-	if (auto result = parse_result.at(argument))
+	if (parse_result.count(argument) != 0)
 	{
-		if (result.isBool())
+		if (const auto &result = parse_result.at(argument))
 		{
-			return result.asBool();
-		}
+			if (result.isBool())
+			{
+				return result.asBool();
+			}
 
-		return true;
+			return true;
+		}
 	}
 
 	return false;

--- a/framework/platform/options.h
+++ b/framework/platform/options.h
@@ -32,7 +32,14 @@ namespace vkb
 class Options
 {
   public:
-	Options(const std::string &usage, const std::vector<std::string> &args);
+	Options() = default;
+
+	/**
+	 * @brief Parses the arguments, forcing an exit if it fails
+	 * @param usage The usage string of the application
+	 * @param args The arguments supplied to the program
+	 */
+	void parse(const std::string &usage, const std::vector<std::string> &args);
 
 	/**
 	 * @brief Helper function that determines if key exists within parsed args

--- a/vulkan_best_practice/vulkan_best_practice.cpp
+++ b/vulkan_best_practice/vulkan_best_practice.cpp
@@ -122,9 +122,9 @@ VulkanBestPractice::VulkanBestPractice()
 		--test TEST_ID            Run test.
 		--batch CATEGORY_NAME     Run all samples within a category, specify 'all' to run all.
 		--benchmark FRAMES        Run app under benchmark mode for n amount of frames.
-        --width WIDTH             The width of the screen if visible [default: 1280].
-        --height HEIGHT           The height of the screen if visible [default: 720].
-        --hide                    Hides the window if possible.
+		--width WIDTH             The width of the screen if visible [default: 1280].
+		--height HEIGHT           The height of the screen if visible [default: 720].
+		--hide                    Hides the window if possible.
 	)");
 }
 

--- a/vulkan_best_practice/vulkan_best_practice.cpp
+++ b/vulkan_best_practice/vulkan_best_practice.cpp
@@ -132,18 +132,18 @@ bool VulkanBestPractice::prepare(Platform &platform)
 {
 	this->platform = &platform;
 
-	if (options->contains("--help"))
+	if (options.contains("--help"))
 	{
 		print_info();
-		options->print_usage();
+		options.print_usage();
 		return false;
 	}
 
 	auto result = false;
 
-	if (options->contains("--batch"))
+	if (options.contains("--batch"))
 	{
-		auto &category_arg = options->get_string("--batch");
+		auto &category_arg = options.get_string("--batch");
 
 		if (category_arg != "all")
 		{
@@ -167,9 +167,9 @@ bool VulkanBestPractice::prepare(Platform &platform)
 		    false,
 		    true);
 	}
-	else if (options->contains("--sample"))
+	else if (options.contains("--sample"))
 	{
-		const auto &sample_arg = options->get_string("--sample");
+		const auto &sample_arg = options.get_string("--sample");
 
 		result = prepare_active_app(
 		    get_create_func(sample_arg),
@@ -177,9 +177,9 @@ bool VulkanBestPractice::prepare(Platform &platform)
 		    false,
 		    false);
 	}
-	else if (options->contains("<sample>"))
+	else if (options.contains("<sample>"))
 	{
-		const auto &sample_arg = options->get_string("<sample>");
+		const auto &sample_arg = options.get_string("<sample>");
 
 		result = prepare_active_app(
 		    get_create_func(sample_arg),
@@ -187,9 +187,9 @@ bool VulkanBestPractice::prepare(Platform &platform)
 		    false,
 		    false);
 	}
-	else if (options->contains("--test"))
+	else if (options.contains("--test"))
 	{
-		const auto &test_arg = options->get_string("--test");
+		const auto &test_arg = options.get_string("--test");
 
 		result = prepare_active_app(
 		    get_create_func(test_arg),
@@ -201,7 +201,7 @@ bool VulkanBestPractice::prepare(Platform &platform)
 	{
 		// The user didn't supply any arguments so print the usage
 		print_info();
-		options->print_usage();
+		options.print_usage();
 		throw std::runtime_error("No arguments given");
 	}
 


### PR DESCRIPTION
Referenced in issue: 
https://github.com/ARM-software/vulkan_best_practice_for_mobile_developers/issues/28 

Entrypoint .exes can run without the same usage required by the `vulkan_best_practice.exe`