### PR TITLE
Added docs redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://github.com/KhronosGroup/Vulkan-Samples</title>
+<meta http-equiv="refresh" content="0; URL=https://github.com/KhronosGroup/Vulkan-Samples">
+<link rel="canonical" href="https://github.com/KhronosGroup/Vulkan-Samples">


### PR DESCRIPTION
Once merged, https://arm-software.github.io/vulkan_best_practice_for_mobile_developers/ should redirect to the new Vulkan Samples repository